### PR TITLE
Fix Google Drive credentials issue

### DIFF
--- a/app.log
+++ b/app.log
@@ -1,12 +1,14 @@
 Google Drive service initialized successfully.
+File 1fjlYRzCbKxQVeeYXkSIfOz0RWcoHg3DW is now publicly accessible with a link
 Google Drive service initialized successfully.
+File 1fjlYRzCbKxQVeeYXkSIfOz0RWcoHg3DW is now publicly accessible with a link
  * Serving Flask app 'app'
  * Debug mode: on
 [31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
  * Running on all addresses (0.0.0.0)
  * Running on http://127.0.0.1:12000
- * Running on http://10.2.25.149:12000
+ * Running on http://10.2.24.141:12000
 [33mPress CTRL+C to quit[0m
  * Restarting with stat
  * Debugger is active!
- * Debugger PIN: 218-567-418
+ * Debugger PIN: 115-895-904


### PR DESCRIPTION
This PR fixes the Google Drive credentials issue by:

- Renaming the credentials file from google-drive-credentials.json.json to google-drive-credentials.json
- Creating necessary upload directories for local storage fallback
- Successfully running the application with Google Drive integration enabled

The application now successfully initializes the Google Drive service and can be accessed at http://127.0.0.1:12000.